### PR TITLE
Add SpotifyAPI to search for tracks and playlist via /play command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>se.michaelthelin.spotify</groupId>
+			<artifactId>spotify-web-api-java</artifactId>
+			<version>7.3.0</version>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/src/main/java/dev/joopie/jambot/api/spotify/ApiSpotifyService.java
+++ b/src/main/java/dev/joopie/jambot/api/spotify/ApiSpotifyService.java
@@ -1,0 +1,93 @@
+package dev.joopie.jambot.api.spotify;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.core5.http.ParseException;
+import org.springframework.stereotype.Service;
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
+import se.michaelthelin.spotify.model_objects.specification.*;
+import se.michaelthelin.spotify.requests.authorization.client_credentials.ClientCredentialsRequest;
+import se.michaelthelin.spotify.requests.data.playlists.GetPlaylistsItemsRequest;
+import se.michaelthelin.spotify.requests.data.tracks.GetTrackRequest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApiSpotifyService {
+    private static final Logger LOGGER = Logger.getLogger(ApiSpotifyService.class.getName());
+    private final SpotifyProperties properties;
+    private SpotifyApi spotifyApi;
+    private ClientCredentialsRequest clientCredentialsRequest;
+
+    private ClientCredentials clientCredentials;
+
+
+    public void getSpotifyAccessToken() {
+        spotifyApi =  new SpotifyApi.Builder()
+                .setClientId(properties.getClientId())
+                .setClientSecret(properties.getClientSecret())
+                .build();
+
+        clientCredentialsRequest =  spotifyApi.clientCredentials()
+                .build();
+
+        try {
+            clientCredentials = clientCredentialsRequest.execute();
+
+            // Set access token for further "spotifyApi" object usage
+            spotifyApi.setAccessToken(clientCredentials.getAccessToken());
+
+            System.out.println("Expires in: " + clientCredentials.getExpiresIn());
+        } catch (IOException | SpotifyWebApiException | ParseException e) {
+            LOGGER.log(Level.SEVERE, "Error: {0}", e.getMessage());
+        }
+    }
+
+    public String getTrack(String trackId) {
+        if (spotifyApi == null || spotifyApi.getAccessToken().isEmpty() || clientCredentials.getExpiresIn() < 0) {
+            getSpotifyAccessToken();
+        }
+
+        GetTrackRequest getTrackRequest = spotifyApi.getTrack(trackId).build();
+
+        try {
+            final Track track = getTrackRequest.execute();
+            String artists = Arrays.stream(track.getArtists()).map(ArtistSimplified::getName).collect(Collectors.joining(","));
+            return String.join("-", artists, track.getName());
+
+        } catch (IOException | SpotifyWebApiException | ParseException e) {
+            LOGGER.log(Level.SEVERE, "Error: {0}", e.getMessage());
+        }
+        return "";
+    }
+
+    public List<String> getTracksFromPlaylist(String playlistId) {
+        if (spotifyApi == null || spotifyApi.getAccessToken().isEmpty()) {
+            getSpotifyAccessToken();
+        }
+        GetPlaylistsItemsRequest playlistsItemsRequest = spotifyApi.getPlaylistsItems(playlistId).build();
+
+        try {
+            final Paging<PlaylistTrack> playlist = playlistsItemsRequest.execute();
+            return Arrays.stream(playlist.getItems())
+                        .map(playlistItem -> (Track) playlistItem.getTrack())
+                        .map(track -> String.join("-" , Arrays.stream(track.getArtists()).map(ArtistSimplified::getName).collect(Collectors.joining(",")),track.getName()))
+                    .toList();
+
+        } catch (IOException | SpotifyWebApiException | ParseException e) {
+            LOGGER.log(Level.SEVERE, "Error: {0}", e.getMessage());
+        }
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/dev/joopie/jambot/api/spotify/SpotifyConfig.java
+++ b/src/main/java/dev/joopie/jambot/api/spotify/SpotifyConfig.java
@@ -1,0 +1,9 @@
+package dev.joopie.jambot.api.spotify;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(SpotifyProperties.class)
+public class SpotifyConfig {
+}

--- a/src/main/java/dev/joopie/jambot/api/spotify/SpotifyProperties.java
+++ b/src/main/java/dev/joopie/jambot/api/spotify/SpotifyProperties.java
@@ -1,0 +1,15 @@
+package dev.joopie.jambot.api.spotify;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConfigurationProperties(prefix = "spotify")
+@ConstructorBinding
+@Getter
+@RequiredArgsConstructor
+public class SpotifyProperties {
+    private final String clientId;
+    private final String clientSecret;
+}

--- a/src/main/java/dev/joopie/jambot/music/command/PlayCommandHandler.java
+++ b/src/main/java/dev/joopie/jambot/music/command/PlayCommandHandler.java
@@ -39,12 +39,9 @@ public class PlayCommandHandler implements CommandHandler {
     private static final String COMMAND_NAME = "jam";
     private static final String COMMAND_OPTION_INPUT_NAME = "input";
     private static final String SPOTIFY_URL = "spotify";
-
     private static final Pattern URL_OR_ID_PATTERN = Pattern.compile("^(http(|s)://.*|[\\w\\-]{11})$");
-
     private final GuildMusicService musicService;
     private final ApiYouTubeService apiYouTubeService;
-
     private final ApiSpotifyService apiSpotifyService;
     private final boolean isAvailable = false;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 jda.token=
 youtube.token=
 
+spotify.clientId=
+spotify.clientSecret=
+
 app.admin-user-id=
 app.update-commands-secret=
 


### PR DESCRIPTION
### Prerequirements and summary of this PR

In order to test this you need to make a [Spotify Developer Application](https://developer.spotify.com/dashboard/login). After creating an application, you can provide the spotify.clientId and the spotify.clientSecret in the application.properties file or inject it via some kind of pipeline. Authorisation via oAuth is handeled in the [ApiSpotifyService.java](https://github.com/carstenflokstra/jambot/blob/master/src/main/java/dev/joopie/jambot/api/spotify/ApiSpotifyService.java?rgh-link-date=2022-12-15T00%3A24%3A10Z) where a request to the authorisation api is being done to receive an access token.

After merging this PR, it is possible to fetch Spotify data. This data is getting parsed into a understandable format into the Youtube API to search for video's. After a video is found, it is being played through the bot.

This also works with playlists. You can add a Spotify playlist ([open.spotify.com/playlist](https://open.spotify.com/playlist)) link to the bot. All the songs in that list will get fetched. After that, it is going to be routed to the search API of YouTube to queue the items.

Thing to watch for is that we have a limitation on the Youtube API. If the quatation is reached, the API will return 403. So maybe we need to do something about that in case someone queues a list with a lot of tracks.

### Related issues:

   - #7 

### This PR contains
- A newly added libary to connect with the Spotify API named [spotify-web-api-java](https://github.com/spotify-web-api-java/spotify-web-api-java)
- A lookup for single track link (ex. [open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT](https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT))
- A lookup for a playlist with tracks (ex. [open.spotify.com/playlist/0H7g3TJaoxqH5a7vO0ClKV](https://open.spotify.com/playlist/0H7g3TJaoxqH5a7vO0ClKV))