### PR TITLE
Fix #101, #105 and #92 

### DIFF
--- a/src/main/java/dev/joopie/jambot/api/spotify/ApiSpotifyService.java
+++ b/src/main/java/dev/joopie/jambot/api/spotify/ApiSpotifyService.java
@@ -48,7 +48,7 @@ public class ApiSpotifyService {
     }
 
 
-    public Optional<Track> getTrack(String link) {
+    public Optional<Track> getTrack(final String link) {
         if (spotifyApi == null || spotifyApi.getAccessToken().isEmpty() || isAccessTokenExpired()) {
             initSpotifyAccessToken();
         }
@@ -73,7 +73,7 @@ public class ApiSpotifyService {
         return Optional.empty();
     }
 
-    public Optional<Track> searchForTrack(String artistName, String trackName) {
+    public Optional<Track> searchForTrack(final String artistName, final String trackName) {
         if (spotifyApi == null || spotifyApi.getAccessToken().isEmpty() || isAccessTokenExpired()) {
             initSpotifyAccessToken();
         }
@@ -102,7 +102,7 @@ public class ApiSpotifyService {
     }
 
 
-    private Optional<String> getSpotifyIdFromLink(String link) {
+    private Optional<String> getSpotifyIdFromLink(final String link) {
             var matcher = SPOTIFY_URL_PATTERN.matcher(link);
             if (matcher.find()) {
                 return Optional.of(matcher.group(2));

--- a/src/main/java/dev/joopie/jambot/api/youtube/ApiYouTubeService.java
+++ b/src/main/java/dev/joopie/jambot/api/youtube/ApiYouTubeService.java
@@ -21,6 +21,7 @@ import java.io.InputStreamReader;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -122,7 +123,8 @@ public class ApiYouTubeService {
     }
 
     private List<String> getVideoIdsFromResponse(HttpEntity entity, final Track track) throws IOException {
-        final var trackSourcesIds = track.getTrackSources().stream().map(TrackSource::getYoutubeId).collect(Collectors.toSet());
+        final var trackSources = track.getTrackSources();
+        final var trackSourcesIds = trackSources == null ? new HashSet<>() : trackSources.stream().map(TrackSource::getYoutubeId).collect(Collectors.toSet());
         var response = parseResponse(entity, SearchResponse.class);
         return Optional.ofNullable(response)
                 .map(SearchResponse::getItems)

--- a/src/main/java/dev/joopie/jambot/listener/SearchFeedbackEventListener.java
+++ b/src/main/java/dev/joopie/jambot/listener/SearchFeedbackEventListener.java
@@ -1,6 +1,8 @@
 package dev.joopie.jambot.listener;
 
 import dev.joopie.jambot.model.TrackSource;
+import dev.joopie.jambot.music.GuildMusicService;
+import dev.joopie.jambot.service.PlayHistoryService;
 import dev.joopie.jambot.service.TrackSourceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,8 @@ public class SearchFeedbackEventListener extends ListenerAdapter {
     private static final String REGEX_2 = "youtu\\.be/([a-zA-Z0-9_-]+)";
     private static final Pattern PATTERN_1 = Pattern.compile(REGEX_1);
     private static final Pattern PATTERN_2 = Pattern.compile(REGEX_2);
+    private final GuildMusicService guildMusicService;
+    private final PlayHistoryService playHistoryService;
 
     private Optional<TrackSource> getSpotifyToYoutubeFromMessage(Message message) {
         return extractYouTubeId(message.getContentStripped()).flatMap(trackSourceService::findByYoutubeId);
@@ -39,12 +43,20 @@ public class SearchFeedbackEventListener extends ListenerAdapter {
         if (componentId.equals("accept")) {
             event.reply("You accepted! :star_struck:  Great to hear that my Dora The Exploring did work out for you. Have fun listening to this banger! :muscle_tone2:").setEphemeral(true).queue();
         } else if (componentId.equals("reject")) {
+
             // Reject the link and delete the SpotifyToYoutube record
             final var trackSource = getSpotifyToYoutubeFromMessage(event.getMessage());
 
             if (trackSource.isPresent()) {
                 trackSource.get().setRejected(true);
                 trackSourceService.save(trackSource.get());
+
+                // Remove from the queue or play next track if the track is already playing
+                guildMusicService.handleFeedback(event.getGuild(), trackSource.get().getYoutubeId());
+
+                // Remove the song from the play history since this is not a valid entry
+                playHistoryService.deleteLatestTrackEntry(event.getUser().getId(), trackSource.get().getTrack());
+
                 event.reply("Thanks for your input! :pray_tone1:  Only together we can make Jambot better. I will try to get another link next time. :wink:").setEphemeral(true).queue();
             } else {
                 log.error("Hmm. Tracksource is empty. This is strange...");

--- a/src/main/java/dev/joopie/jambot/listener/SearchFeedbackEventListener.java
+++ b/src/main/java/dev/joopie/jambot/listener/SearchFeedbackEventListener.java
@@ -52,7 +52,7 @@ public class SearchFeedbackEventListener extends ListenerAdapter {
                 trackSourceService.save(trackSource.get());
 
                 // Remove from the queue or play next track if the track is already playing
-                guildMusicService.handleFeedback(event.getGuild(), trackSource.get().getYoutubeId());
+                guildMusicService.removeFromQueueByYoutubeId(event.getGuild(), trackSource.get().getYoutubeId());
 
                 // Remove the song from the play history since this is not a valid entry
                 playHistoryService.deleteLatestTrackEntry(event.getUser().getId(), trackSource.get().getTrack());

--- a/src/main/java/dev/joopie/jambot/music/GuildMusicService.java
+++ b/src/main/java/dev/joopie/jambot/music/GuildMusicService.java
@@ -137,6 +137,15 @@ public class GuildMusicService {
         musicPlayer.remove(songIndex);
     }
 
+    public void remove(final Member member, final String mediaId) {
+        final var musicPlayer = getAudioPlayer(member.getGuild());
+
+        assertConnectedToVoiceChannel(musicPlayer);
+        assertMemberInSameVoiceChannel(musicPlayer, member);
+
+        musicPlayer.remove(mediaId);
+    }
+
     public void clear(final Member member) {
         final var musicPlayer = getAudioPlayer(member.getGuild());
 
@@ -210,6 +219,18 @@ public class GuildMusicService {
     private void assertMemberInSameVoiceChannel(final GuildMusicPlayer musicPlayer, final Member member) {
         if (!musicPlayer.isSameVoiceChannelAsMember(member)) {
             throw new JambotMusicServiceException("Join the voice channel!");
+        }
+    }
+
+    public void handleFeedback(final Guild guild, final String youtubeId) {
+        var musicPlayer = getAudioPlayer(guild);
+        var tracks = musicPlayer.getQueuedAudioTracks();
+
+        if (tracks != null && !tracks.isEmpty() && tracks.getFirst().getInfo().uri.contains(youtubeId)) {
+            musicPlayer.remove(youtubeId);
+            musicPlayer.next();
+        } else {
+            musicPlayer.remove(youtubeId);
         }
     }
 }

--- a/src/main/java/dev/joopie/jambot/music/GuildMusicService.java
+++ b/src/main/java/dev/joopie/jambot/music/GuildMusicService.java
@@ -222,7 +222,7 @@ public class GuildMusicService {
         }
     }
 
-    public void handleFeedback(final Guild guild, final String youtubeId) {
+    public void removeFromQueueByYoutubeId(final Guild guild, final String youtubeId) {
         var musicPlayer = getAudioPlayer(guild);
         var tracks = musicPlayer.getQueuedAudioTracks();
 

--- a/src/main/java/dev/joopie/jambot/music/command/PlayCommandHandler.java
+++ b/src/main/java/dev/joopie/jambot/music/command/PlayCommandHandler.java
@@ -144,8 +144,8 @@ public class PlayCommandHandler extends ListenerAdapter implements CommandHandle
 
     private Optional<String> handleSpotifyLink(final String input) {
         if (input.contains("track")) {
-            final var spotifyResult = searchService.getTrack(input);
-            return spotifyResult.isPresent() ? searchService.performYoutubeSearch(spotifyResult.get()) : Optional.empty();
+            return searchService.getTrack(input)
+                    .flatMap(searchService::performYoutubeSearch);
         }
 
         return Optional.empty();

--- a/src/main/java/dev/joopie/jambot/music/command/SearchCommandHandler.java
+++ b/src/main/java/dev/joopie/jambot/music/command/SearchCommandHandler.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.RestAction;
+import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -95,11 +96,11 @@ public class SearchCommandHandler implements CommandHandler, CommandAutocomplete
 
             final var videoId = searchService.performSpotifyAndYoutubeSearch(artistName, trackName);
 
-            if (videoId.isEmpty()) {
+            if (videoId.isEmpty() || Strings.isBlank(videoId.get())) {
                 return event.reply("We could not find any results with your search **%s - %s**".formatted(artistName, trackName)).setEphemeral(true);
             } else {
-                musicService.play(event.getMember(), videoId);
-                final var parsedVideoId = GuildMusicService.YOUTUBE_URL + videoId;
+                musicService.play(event.getMember(), videoId.get());
+                final var parsedVideoId = GuildMusicService.YOUTUBE_URL + videoId.get();
 
                 // Create and send the message with buttons
                 return event.getHook().sendMessage(

--- a/src/main/java/dev/joopie/jambot/repository/PlayHistoryRepository.java
+++ b/src/main/java/dev/joopie/jambot/repository/PlayHistoryRepository.java
@@ -14,6 +14,6 @@ public interface PlayHistoryRepository extends ListCrudRepository<PlayHistory, L
 
     @Modifying
     @Transactional
-    @Query(value = "DELETE FROM play_history WHERE id = (SELECT id FROM play_history WHERE user_id = :userId AND track_id = :trackId AND DATE(created_at) = CURRENT_DATE ORDER BY created_at DESC LIMIT 1)", nativeQuery = true)
-    void deleteLatestByUserIdAndTrackIdAndCreatedAtEqualsCurrentDate(@Param("userId") String userId, @Param("trackId") Long trackId);
+    @Query(value = "DELETE FROM play_history WHERE user_id = :userId AND track_id = :trackId ORDER BY created_at DESC LIMIT 1)", nativeQuery = true)
+    void deleteLatestByUserIdAndTrackId(@Param("userId") String userId, @Param("trackId") Long trackId);
 }

--- a/src/main/java/dev/joopie/jambot/repository/PlayHistoryRepository.java
+++ b/src/main/java/dev/joopie/jambot/repository/PlayHistoryRepository.java
@@ -1,10 +1,19 @@
 package dev.joopie.jambot.repository;
 
 import dev.joopie.jambot.model.PlayHistory;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PlayHistoryRepository extends ListCrudRepository<PlayHistory, Long> {
     void deleteByGuildId(String guildId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM play_history WHERE id = (SELECT id FROM play_history WHERE user_id = :userId AND track_id = :trackId AND DATE(created_at) = CURRENT_DATE ORDER BY created_at DESC LIMIT 1)", nativeQuery = true)
+    void deleteLatestByUserIdAndTrackIdAndCreatedAtEqualsCurrentDate(@Param("userId") String userId, @Param("trackId") Long trackId);
 }

--- a/src/main/java/dev/joopie/jambot/service/PlayHistoryService.java
+++ b/src/main/java/dev/joopie/jambot/service/PlayHistoryService.java
@@ -18,7 +18,7 @@ public class PlayHistoryService {
     }
     @Transactional
     public void deleteLatestTrackEntry(final String userId, final Track track) {
-         playHistoryRepository.deleteLatestByUserIdAndTrackIdAndCreatedAtEqualsCurrentDate(userId, track.getId());
+         playHistoryRepository.deleteLatestByUserIdAndTrackId(userId, track.getId());
     }
 
     @Transactional

--- a/src/main/java/dev/joopie/jambot/service/PlayHistoryService.java
+++ b/src/main/java/dev/joopie/jambot/service/PlayHistoryService.java
@@ -2,6 +2,7 @@ package dev.joopie.jambot.service;
 
 
 import dev.joopie.jambot.model.PlayHistory;
+import dev.joopie.jambot.model.Track;
 import dev.joopie.jambot.repository.PlayHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.Guild;
@@ -14,6 +15,10 @@ public class PlayHistoryService {
     private final PlayHistoryRepository playHistoryRepository;
     public PlayHistory save(PlayHistory playHistory) {
         return playHistoryRepository.save(playHistory);
+    }
+    @Transactional
+    public void deleteLatestTrackEntry(final String userId, final Track track) {
+         playHistoryRepository.deleteLatestByUserIdAndTrackIdAndCreatedAtEqualsCurrentDate(userId, track.getId());
     }
 
     @Transactional

--- a/src/main/java/dev/joopie/jambot/service/SearchService.java
+++ b/src/main/java/dev/joopie/jambot/service/SearchService.java
@@ -31,7 +31,7 @@ public class SearchService {
                 trackSourceService.save(trackSource);
             }
 
-            return Optional.of(trackSource.getYoutubeId());
+            return Strings.isBlank(trackSource.getYoutubeId()) ? Optional.of(trackSource.getYoutubeId()) : Optional.empty();
         }
 
         return track.getTrackSources().stream().filter(trackSource -> !trackSource.isRejected()).map(TrackSource::getYoutubeId).findFirst();


### PR DESCRIPTION
Closes #101 #105, #92

* Performs Youtube Search if Spotify gives not result using the old search function. Tested with `Wasted Penguinz - Forever Today` which is not available on Spotify. 
* If a user rejects a track and it is playing in the bot, it plays the next song
* If a user rejects a track, it will remove this and other occurences with the same `videoId` from the queue. 
* If a user reject a track and it is playing, it will be removed from the play history table by that `userId`, `trackId` and the `current date`. Songs that are in the `PlayHistory` table are not being removed. Songs in the queue are automatically not added to this table since it only inserts data when the song gets played.
* Use the Track model to get Tracksources to filter on rejected Youtube VideoID's instead of querying the `TrackSource` table on that `videoId`. This prevents that songs gets filtered out if they are rejected by another search action. Before this, once rejected, this video would never show up anymore.
* Build extra validation that checks if the `trackName` is in the Youtube video to prevent faulty insertions into the `PlayHistory` table.
* Removed Youtube Channel checking because this was breaking the search functionality massively. I came to the conclusion that some tracks are published by the label, which resulted in that tracks of the artist itself got priority. This meant that tracks got played from the artist that were not even right given the search string. It only checks for durations now of the Spotify Track plus and minus 15 seconds. This will hopefully get better results faster instead of 6 search attempts we are seeing now.
* Some refactoring and making a lot of method parameters final


--- 
# To do's after merge:
- [ ] Remove all the records in TrackSource that have `rejected = 1` since it could be that there are faulty rejected records in the database. This won't have a lot of consequences since a lot of people have already found the right track with the feedback system. 
- [ ]  Compare the createdAt dates in play_history with the createdAt dates in track_source for the same track_id with a join or sub-query. Delete any play_history records that were created before the latest non-rejected (if any since you delete those here above) track_source record.